### PR TITLE
Type-check scripts only when it contains Python files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,13 @@ jobs:
         run: uv run ruff format --check polars_ti tests scripts
 
       - name: Mypy strict
-        run: uv run mypy --strict polars_ti scripts
+        run: |
+          # Match scripts/check.sh: only type-check scripts/ when it has Python
+          # files (it currently holds only check.sh, and mypy errors on a dir
+          # with no .py files).
+          targets=(polars_ti)
+          compgen -G "scripts/*.py" > /dev/null && targets+=(scripts)
+          uv run mypy --strict "${targets[@]}"
 
       - name: Syntax check
         run: uv run python -m compileall -q polars_ti tests scripts


### PR DESCRIPTION
## Summary

Final CI fix. The Quality job ran `mypy --strict polars_ti scripts`, but `scripts/` has no `.py` files (only `check.sh`), so mypy exited 2 and failed the build. `scripts/check.sh` already guards this by adding `scripts` to the mypy targets only when `scripts/*.py` exists; this mirrors that guard in the workflow.

Verified locally: `mypy --strict polars_ti` -> Success (297 files); the guarded command exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)